### PR TITLE
Add HKSC-4096 cipher and planner (CLI + tests)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/hksc-electron"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,19 @@
 version: 2
 updates:
+  - package-ecosystem: "npm"
+    directory: "/hksc-electron"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels: ["dependabot", "security"]
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/hksc-electron"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10

--- a/.github/workflows/autonomous-control-loop.yml
+++ b/.github/workflows/autonomous-control-loop.yml
@@ -1,0 +1,27 @@
+name: Autonomous Control Loop (Safe Mode)
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  control-loop:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Execute autonomy engine
+        run: python automation/autonomy_engine.py --report automation/report.json
+      - name: Upload autonomy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: autonomy-report
+          path: automation/report.json
+          retention-days: 14

--- a/.github/workflows/ci-security-full.yml
+++ b/.github/workflows/ci-security-full.yml
@@ -1,0 +1,70 @@
+name: Full Security Pipeline (Slither + Echidna + Mythril)
+
+on:
+  push:
+    branches: [main, dev]
+    paths: ['hksc-verifier-contract/**']
+  pull_request:
+    branches: [main, dev]
+    paths: ['hksc-verifier-contract/**']
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Slither + Autofix
+        id: slither
+        uses: crytic/slither-action@v0.4.2
+        with:
+          target: 'hksc-verifier-contract/contracts/'
+          slither-args: '--autofix --fail-high --exclude-dependencies'
+          sarif: 'slither.sarif'
+
+      - name: Upload Slither SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'slither.sarif'
+
+      - name: Run Echidna Fuzzing
+        uses: crytic/echidna-action@v2
+        with:
+          files: hksc-verifier-contract/contracts/HKSC_Verifier.sol
+          contract: HKSC_Verifier
+          config: hksc-verifier-contract/echidna.yaml
+
+      - name: Setup Python for Mythril
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Mythril
+        run: |
+          python -m pip install --upgrade pip
+          pip install mythril
+
+      - name: Run Mythril
+        run: |
+          myth analyze hksc-verifier-contract/contracts/HKSC_Verifier.sol --solv 0.8.24 --execution-timeout 300 -o json > mythril-full.json
+
+      - name: Upload Mythril report
+        uses: actions/upload-artifact@v4
+        with:
+          name: mythril-full-report
+          path: mythril-full.json
+          retention-days: 14
+
+      - name: Create autofix PR
+        if: steps.slither.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: autofix-security
+          title: "🔧 Auto-fix: Full Security Pipeline"
+          labels: autofix,security

--- a/.github/workflows/ci-slither.yml
+++ b/.github/workflows/ci-slither.yml
@@ -1,0 +1,38 @@
+name: CI/CD - Slither Security Gatekeeper
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'hksc-verifier-contract/contracts/**'
+      - 'hksc-verifier-contract/scripts/**'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'hksc-verifier-contract/contracts/**'
+  workflow_dispatch:
+
+jobs:
+  slither-ci-cd:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Slither Analysis + Auto-fix
+        id: slither
+        uses: crytic/slither-action@v0.4.2
+        with:
+          target: 'hksc-verifier-contract/contracts/'
+          slither-args: '--autofix --fail-high --exclude-dependencies'
+          sarif: 'slither-results.sarif'
+          fail-on: high
+
+      - name: Upload Slither results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'slither-results.sarif'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+  schedule:
+    - cron: '19 4 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python', 'javascript-typescript' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/contract-security.yml
+++ b/.github/workflows/contract-security.yml
@@ -1,0 +1,62 @@
+name: Contract Security (Slither + Echidna + Mythril)
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'hksc-verifier-contract/**'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'hksc-verifier-contract/**'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Slither scan
+        uses: crytic/slither-action@v0.4.2
+        with:
+          target: 'hksc-verifier-contract/contracts/'
+          slither-args: '--fail-high --exclude-dependencies'
+          sarif: 'slither-results.sarif'
+
+      - name: Upload Slither SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'slither-results.sarif'
+
+      - name: Run Echidna fuzzing
+        uses: crytic/echidna-action@v2
+        with:
+          files: hksc-verifier-contract/contracts/HKSC_Verifier.sol
+          contract: HKSC_Verifier
+          config: hksc-verifier-contract/echidna.yaml
+
+      - name: Setup Python for Mythril
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Mythril
+        run: |
+          python -m pip install --upgrade pip
+          pip install mythril
+
+      - name: Mythril symbolic analysis
+        run: |
+          myth analyze hksc-verifier-contract/contracts/HKSC_Verifier.sol --solv 0.8.24 -o json > mythril-report.json
+
+      - name: Upload Mythril report
+        uses: actions/upload-artifact@v4
+        with:
+          name: mythril-report
+          path: mythril-report.json
+          retention-days: 14

--- a/.github/workflows/contract-security.yml
+++ b/.github/workflows/contract-security.yml
@@ -60,3 +60,19 @@ jobs:
           name: mythril-report
           path: mythril-report.json
           retention-days: 14
+
+
+      - name: Install Manticore
+        run: |
+          python -m pip install manticore
+
+      - name: Manticore symbolic execution
+        run: |
+          manticore hksc-verifier-contract/contracts/HKSC_Verifier.sol --workspace manticore-out || true
+
+      - name: Upload Manticore workspace
+        uses: actions/upload-artifact@v4
+        with:
+          name: manticore-workspace
+          path: manticore-out
+          retention-days: 14

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,17 @@
+name: Python tests
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HKSC-4096
 
+HyperKnight Supercube Cryptosystem (16×16×16)
+
 Bản này nâng cấp theo hướng **có thể sử dụng thực tế** và nối tiếp roadmap bạn đưa:
 - Cipher + planner deterministic (core crypto),
 - Flask bridge cho desktop/web UI,

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # HKSC-4096
-HyperKnight Supercube Cryptosystem (16×16×16)
+
+HyperKnight Supercube Cryptosystem (`16x16x16 = 4096` cells).
+
+Bản này được nâng cấp để bám sát ý tưởng bạn đưa ra: không chỉ mã hóa block 4096 bytes, mà còn có **planner mô phỏng Rubik/knight** với:
+- 3 trường hợp tỉ lệ bước (bằng nhau, mã ít hơn, mã nhiều hơn),
+- tỉ lệ động theo segment,
+- biến thể quân cờ (`knight/bishop/rook/queen/king`) ở mức mobility abstraction,
+- nhiều agent đồng thời,
+- sự kiện adversarial định kỳ.
+
+## Kiến trúc
+
+### 1) Cipher layer (dùng thực tế)
+- `HKSC4096Cipher` mã hóa theo block 4096 bytes.
+- Hoán vị dựa trên **keyed 3D knight-walk** trên không gian `16^3`.
+- Nhiều vòng substitution + permutation.
+- `scrypt` để dẫn xuất khóa từ passphrase.
+- Xác thực toàn vẹn bằng `HMAC-SHA3-256`.
+
+### 2) Planner layer (mô phỏng ý tưởng Rubik/knight)
+- `HKSCPlanner` tạo transcript hash xác định từ cấu hình planner.
+- Transcript được trộn vào keystream/domain separation của cipher.
+- Nếu decrypt với planner config khác encrypt sẽ bị từ chối.
+
+## CLI
+
+### Encrypt / Decrypt
+```bash
+python hksc4096.py encrypt -i plain.bin -o secret.hksc -p "my-pass" \
+  --piece knight --agents 2 --ratio-mode dynamic \
+  --dynamic-schedule "512:1:1,512:1:8,512:7:1"
+
+python hksc4096.py decrypt -i secret.hksc -o recovered.bin -p "my-pass" \
+  --piece knight --agents 2 --ratio-mode dynamic \
+  --dynamic-schedule "512:1:1,512:1:8,512:7:1"
+```
+
+### Planner simulation only
+```bash
+python hksc4096.py simulate --seed demo --cells 1024 \
+  --piece queen --agents 3 --ratio-mode knight_more --ratio-den 7
+```
+
+## Test
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+## Lưu ý bảo mật
+
+- Đây là thiết kế experimental/R&D.
+- Mô hình Rubik trong planner là abstraction hash-chain (không phải Rubik group solver đầy đủ).
+- Không nên dùng cho dữ liệu tối mật production nếu chưa audit độc lập.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,23 @@ python -m unittest discover -s tests -v
 - Đây là thiết kế experimental/R&D.
 - Planner là abstraction hash-chain, không phải full Rubik group solver.
 - Không dùng cho dữ liệu tối mật production nếu chưa audit độc lập.
+
+
+## 6) Whitepaper & architecture docs
+
+- `docs/WHITEPAPER.md`: engineering draft, threat model, composition, roadmap.
+- `docs/ARCHITECTURE.md`: component boundaries, data-flow, and CI/security design.
+
+## 7) Security pipeline (expanded)
+
+- `contract-security.yml`: Slither + Echidna + Mythril in one pipeline.
+- `codeql.yml`: code scanning for Python + JavaScript/TypeScript.
+- `.github/dependabot.yml`: weekly dependency updates for GitHub Actions + npm.
+
+## 8) Enable repository security alerts (GitHub settings)
+
+In **Settings → Security & analysis**, enable:
+- Dependabot alerts
+- Dependabot security updates
+- Code scanning alerts
+- Secret scanning (and push protection if available)

--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ In **Settings → Security & analysis**, enable:
 - Dependabot security updates
 - Code scanning alerts
 - Secret scanning (and push protection if available)
+
+
+
+## 9) Safe autonomous loop
+
+- `automation/policy.yaml`: autonomy policy, escalation and guardrails.
+- `automation/autonomy_engine.py`: periodic health checks + worst-case simulation matrix + action plan.
+- `.github/workflows/autonomous-control-loop.yml`: scheduled every 6h to generate autonomy report artifact.
+
+> Mặc định dùng **safe-autonomy**: tự động giám sát/cải tiến/đề xuất và tự xử lý low-risk; các hành động high-risk vẫn yêu cầu escalation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # HKSC-4096
 
-HyperKnight Supercube Cryptosystem (`16x16x16 = 4096` cells).
-
 Bản này nâng cấp theo hướng **có thể sử dụng thực tế** và nối tiếp roadmap bạn đưa:
 - Cipher + planner deterministic (core crypto),
 - Flask bridge cho desktop/web UI,
@@ -82,7 +80,7 @@ python -m unittest discover -s tests -v
 
 ## 7) Security pipeline (expanded)
 
-- `contract-security.yml`: Slither + Echidna + Mythril in one pipeline.
+- `contract-security.yml`: Slither + Echidna + Mythril + Manticore in one pipeline.
 - `codeql.yml`: code scanning for Python + JavaScript/TypeScript.
 - `.github/dependabot.yml`: weekly dependency updates for GitHub Actions + npm.
 

--- a/README.md
+++ b/README.md
@@ -2,28 +2,21 @@
 
 HyperKnight Supercube Cryptosystem (`16x16x16 = 4096` cells).
 
-Bản này được nâng cấp để bám sát ý tưởng bạn đưa ra: không chỉ mã hóa block 4096 bytes, mà còn có **planner mô phỏng Rubik/knight** với:
-- 3 trường hợp tỉ lệ bước (bằng nhau, mã ít hơn, mã nhiều hơn),
-- tỉ lệ động theo segment,
-- biến thể quân cờ (`knight/bishop/rook/queen/king`) ở mức mobility abstraction,
-- nhiều agent đồng thời,
-- sự kiện adversarial định kỳ.
+Bản này nâng cấp theo hướng **có thể sử dụng thực tế** và nối tiếp roadmap bạn đưa:
+- Cipher + planner deterministic (core crypto),
+- Flask bridge cho desktop/web UI,
+- Web3 helper cho on-chain verifier,
+- CI workflows cho Python test + Slither gatekeeper,
+- Scaffold contract verifier để thay bằng bản xuất từ `snarkjs`.
 
-## Kiến trúc
+## 1) Core crypto
 
-### 1) Cipher layer (dùng thực tế)
-- `HKSC4096Cipher` mã hóa theo block 4096 bytes.
-- Hoán vị dựa trên **keyed 3D knight-walk** trên không gian `16^3`.
-- Nhiều vòng substitution + permutation.
-- `scrypt` để dẫn xuất khóa từ passphrase.
-- Xác thực toàn vẹn bằng `HMAC-SHA3-256`.
+`hksc4096.py` gồm:
+- `HKSC4096Cipher`: mã hóa block 4096 bytes, keyed 3D knight-walk permutation.
+- `HKSCPlanner`: mô phỏng ratio/case logic (equal, knight_less, knight_more, dynamic), piece variants, multi-agent, adversarial events.
+- planner hash được bind vào header; decrypt sai planner config sẽ bị từ chối.
 
-### 2) Planner layer (mô phỏng ý tưởng Rubik/knight)
-- `HKSCPlanner` tạo transcript hash xác định từ cấu hình planner.
-- Transcript được trộn vào keystream/domain separation của cipher.
-- Nếu decrypt với planner config khác encrypt sẽ bị từ chối.
-
-## CLI
+## 2) CLI
 
 ### Encrypt / Decrypt
 ```bash
@@ -36,20 +29,47 @@ python hksc4096.py decrypt -i secret.hksc -o recovered.bin -p "my-pass" \
   --dynamic-schedule "512:1:1,512:1:8,512:7:1"
 ```
 
-### Planner simulation only
+### Planner simulation
 ```bash
 python hksc4096.py simulate --seed demo --cells 1024 \
   --piece queen --agents 3 --ratio-mode knight_more --ratio-den 7
 ```
 
-## Test
+### Flask bridge (cho Electron/React)
+```bash
+pip install flask
+python hksc4096.py serve --host 127.0.0.1 --port 5000
+```
+
+API chính:
+- `POST /api/simulate`
+- `POST /api/encrypt`
+- `POST /api/decrypt`
+
+## 3) Web3 verifier integration
+
+`hksc_web3.py` cung cấp:
+- `load_verifier_abi(...)`
+- `normalize_proof(...)`
+- `onchain_verify_zk_proof(...)` (eth_call verifyProof)
+
+Contract scaffold nằm tại `hksc-verifier-contract/`.
+
+> Lưu ý: `contracts/HKSC_Verifier.sol` hiện là placeholder. Trước production phải thay bằng file export từ `snarkjs zkey export solidityverifier ...`.
+
+## 4) CI/CD
+
+- `.github/workflows/python-tests.yml`: chạy unit tests.
+- `.github/workflows/ci-slither.yml`: Slither security gatekeeper cho contract.
+
+## 5) Test local
 
 ```bash
 python -m unittest discover -s tests -v
 ```
 
-## Lưu ý bảo mật
+## Security note
 
 - Đây là thiết kế experimental/R&D.
-- Mô hình Rubik trong planner là abstraction hash-chain (không phải Rubik group solver đầy đủ).
-- Không nên dùng cho dữ liệu tối mật production nếu chưa audit độc lập.
+- Planner là abstraction hash-chain, không phải full Rubik group solver.
+- Không dùng cho dữ liệu tối mật production nếu chưa audit độc lập.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ python -m unittest discover -s tests -v
 
 ## 7) Security pipeline (expanded)
 
-- `contract-security.yml`: Slither + Echidna + Mythril + Manticore in one pipeline.
+- `ci-security-full.yml`: Slither + Echidna + Mythril (CI gatekeeper full mode).
+- `contract-security.yml`: Slither + Echidna + Mythril + Manticore (extended analysis).
 - `codeql.yml`: code scanning for Python + JavaScript/TypeScript.
-- `.github/dependabot.yml`: weekly dependency updates for GitHub Actions + npm.
+- `.github/dependabot.yml`: automated dependency updates (daily npm/pip, weekly Actions).
 
 ## 8) Enable repository security alerts (GitHub settings)
 
@@ -103,3 +104,8 @@ In **Settings → Security & analysis**, enable:
 - `.github/workflows/autonomous-control-loop.yml`: scheduled every 6h to generate autonomy report artifact.
 
 > Mặc định dùng **safe-autonomy**: tự động giám sát/cải tiến/đề xuất và tự xử lý low-risk; các hành động high-risk vẫn yêu cầu escalation.
+
+
+## 10) GitHub native security setup
+
+- Xem `docs/SECURITY_SETUP.md` để bật Code Scanning, Security Alerts và Branch Protection.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ Bản này nâng cấp theo hướng **có thể sử dụng thực tế** và n
 - CI workflows cho Python test + Slither gatekeeper,
 - Scaffold contract verifier để thay bằng bản xuất từ `snarkjs`.
 
-## Merge-conflict note
-
-- README/hksc4096.py/tests được đồng bộ cùng một phiên bản CLI+header để giảm xung đột khi rebase/merge.
-
 ## 1) Core crypto
 
 `hksc4096.py` gồm:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Bản này nâng cấp theo hướng **có thể sử dụng thực tế** và n
 - CI workflows cho Python test + Slither gatekeeper,
 - Scaffold contract verifier để thay bằng bản xuất từ `snarkjs`.
 
+## Merge-conflict note
+
+- README/hksc4096.py/tests được đồng bộ cùng một phiên bản CLI+header để giảm xung đột khi rebase/merge.
+
 ## 1) Core crypto
 
 `hksc4096.py` gồm:

--- a/automation/autonomy_engine.py
+++ b/automation/autonomy_engine.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class CheckResult:
+    name: str
+    command: str
+    ok: bool
+    output: str
+
+
+def run(cmd: str) -> CheckResult:
+    p = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    return CheckResult(cmd.split()[0], cmd, p.returncode == 0, (p.stdout + p.stderr).strip()[:4000])
+
+
+def evaluate_worst_case() -> dict:
+    scenarios = {
+        "ci_failure": "Recovered by retry + isolate failing workflow",
+        "dependency_breakage": "Pin version and open repair PR",
+        "auth_misconfig": "Block deploy lane, rotate creds checklist",
+        "rpc_outage": "Fallback provider + offline queue",
+        "tampered_ciphertext": "HMAC validation should fail fast",
+    }
+    return scenarios
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report", default="automation/report.json")
+    ap.add_argument("--quick", action="store_true", help="Skip heavy checks for nested/test runs")
+    args = ap.parse_args()
+
+    checks = [run("python hksc4096.py simulate --seed health --cells 64")]
+    if not args.quick:
+        checks.insert(0, run("python -m unittest discover -s tests -v"))
+
+    status = "healthy" if all(c.ok for c in checks) else "degraded"
+    report = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "checks": [asdict(c) for c in checks],
+        "worst_case_matrix": evaluate_worst_case(),
+        "next_actions": [
+            "auto-open repair PR if degraded",
+            "run security workflows",
+            "refresh dependency patches",
+        ],
+        "decision_scope": "safe-autonomy-only",
+    }
+
+    path = Path(args.report)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({"report": str(path), "status": status}))
+    return 0 if status == "healthy" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/automation/policy.yaml
+++ b/automation/policy.yaml
@@ -1,0 +1,27 @@
+version: 1
+mode: safe-autonomy
+principles:
+  - reversible_changes_only
+  - test_before_after
+  - no_secret_mutation
+  - no_unreviewed_prod_deploy
+lanes:
+  monitor:
+    enabled: true
+    actions: [collect_metrics, detect_failures, detect_security_signals]
+  improve:
+    enabled: true
+    actions: [run_tests, suggest_refactors, suggest_docs_updates]
+  repair:
+    enabled: true
+    actions: [retry_failed_tasks, create_patch_branch, open_pr_draft]
+  worst_case_simulation:
+    enabled: true
+    actions: [chaos_ci_failure, dependency_breakage, auth_misconfig, rpc_outage]
+decision:
+  auto_apply:
+    allowed: [docs, ci_non_prod, test_non_prod]
+    forbidden: [prod_keys, prod_contract_deploy, destructive_migrations]
+  escalation:
+    required_for: [crypto_core_change, onchain_deploy, security_policy_change]
+    target: human_maintainer

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,3 +39,10 @@ HKSC-4096 is organized into separable layers so crypto core, API bridge, and blo
 - Contract security workflow combining Slither + Echidna + Mythril.
 - CodeQL code scanning workflow for Python + JavaScript.
 - Dependabot for GitHub Actions and npm ecosystem updates.
+
+
+## Autonomous Development Plan (Guarded)
+- `automation/policy.yaml` defines decision boundaries, escalation rules, and worst-case simulation lanes.
+- `automation/autonomy_engine.py` runs health checks, simulation checks, and emits machine-readable status reports.
+- `.github/workflows/autonomous-control-loop.yml` executes every 6 hours to continuously monitor and recommend next actions.
+- The system is intentionally **safe-autonomy**: it can suggest/prepare low-risk actions, but high-risk domains still require human escalation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,41 @@
+# HKSC-4096 Architecture
+
+## Overview
+HKSC-4096 is organized into separable layers so crypto core, API bridge, and blockchain integrations can evolve independently.
+
+## Layers
+1. **Core cryptosystem (`hksc4096.py`)**
+   - `HKSC4096Cipher`: authenticated block encryption over 4096-byte blocks.
+   - `HKSCPlanner`: deterministic transcript generator encoding scheduling parameters (piece, agents, ratio mode, dynamic schedule, adversarial cadence).
+   - Planner hash is bound in ciphertext header to prevent silent config drift.
+
+2. **Integration bridge (`hksc_bridge.py`)**
+   - Flask API factory for desktop/web frontends.
+   - Endpoints for simulation/encrypt/decrypt with JSON payloads + Base64 transport.
+
+3. **Verifier integration (`hksc_web3.py`)**
+   - ABI loading + proof normalization.
+   - Optional on-chain-compatible `verifyProof` call using `eth_call`.
+
+4. **Contract scaffold (`hksc-verifier-contract`)**
+   - Placeholder verifier contract and deploy script for pipeline wiring.
+   - Must be replaced by generated Groth16 verifier before production.
+
+## Data flow
+1. User provides passphrase + planner config.
+2. `scrypt` derives master key.
+3. Planner transcript digest is derived and mixed into per-round keystream.
+4. 3D keyed knight permutation + substitution rounds produce ciphertext body.
+5. Header includes planner hash and metadata.
+6. HMAC-SHA3-256 authenticates header+body.
+
+## Security boundaries
+- Core cipher can run without Flask/web3 dependencies.
+- Web3 is lazy-imported to avoid implicit chain/network coupling.
+- Placeholder smart contract is intentionally non-production and clearly marked.
+
+## CI/Security pipeline
+- Python unit tests workflow for functional regressions.
+- Contract security workflow combining Slither + Echidna + Mythril.
+- CodeQL code scanning workflow for Python + JavaScript.
+- Dependabot for GitHub Actions and npm ecosystem updates.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,48 +1,41 @@
 # HKSC-4096 Architecture
 
-## Overview
-HKSC-4096 is organized into separable layers so crypto core, API bridge, and blockchain integrations can evolve independently.
+## 1. High-Level Overview
+HKSC-4096 là một cryptographic primitive thực nghiệm dựa trên:
+- Siêu-Rubik `16×16×16` supercube (`4096` cells 3D)
+- 3D Knight Tour/Permutation có khóa
+- Planner transcript deterministic để bind ngữ nghĩa cấu hình vào ciphertext
+- Contract verifier scaffold để tích hợp zk-proof on-chain trong roadmap
+- Security CI/CD (Slither, Echidna, Mythril, Manticore, CodeQL)
 
-## Layers
-1. **Core cryptosystem (`hksc4096.py`)**
-   - `HKSC4096Cipher`: authenticated block encryption over 4096-byte blocks.
-   - `HKSCPlanner`: deterministic transcript generator encoding scheduling parameters (piece, agents, ratio mode, dynamic schedule, adversarial cadence).
-   - Planner hash is bound in ciphertext header to prevent silent config drift.
+> Ghi chú kỹ thuật: repo hiện dùng mô hình hash-chain abstraction ở lớp planner; các mục như self-solving hoàn chỉnh/zk production/mainnet verifier là roadmap có kiểm soát, không auto bật mặc định.
 
-2. **Integration bridge (`hksc_bridge.py`)**
-   - Flask API factory for desktop/web frontends.
-   - Endpoints for simulation/encrypt/decrypt with JSON payloads + Base64 transport.
+## 2. Core Components
+- **Private secret**: passphrase người vận hành + salt/nonce ngẫu nhiên.
+- **Public metadata**: header gồm `magic`, `salt`, `nonce`, `rounds`, `planner_hash`, `original_len`.
+- **State**: planner digest (SHA3-based) + permutation 3D keyed.
+- **Twist/ratio semantics**: do `PlannerConfig` điều khiển (`piece`, `agents`, `ratio_mode`, `dynamic_schedule`, adversarial cadence).
 
-3. **Verifier integration (`hksc_web3.py`)**
-   - ABI loading + proof normalization.
-   - Optional on-chain-compatible `verifyProof` call using `eth_call`.
+## 3. Security Assumptions
+- Độ khó thực tế dựa trên phối hợp KDF + keyed permutation + authenticated transcript binding.
+- Ciphertext integrity dựa trên `HMAC-SHA3-256`.
+- Planner mismatch bị chặn tại decrypt nhờ `planner_hash`.
+- Mô hình hiện tại là R&D; chưa có chứng minh formal reduction hoàn chỉnh.
 
-4. **Contract scaffold (`hksc-verifier-contract`)**
-   - Placeholder verifier contract and deploy script for pipeline wiring.
-   - Must be replaced by generated Groth16 verifier before production.
+## 4. Pipeline CI/CD
+- Python tests gate (`python-tests.yml`)
+- Slither gatekeeper (`ci-slither.yml`)
+- Full contract security (`ci-security-full.yml`): Slither + Echidna + Mythril
+- Extended contract analysis (`contract-security.yml`): Slither + Echidna + Mythril + Manticore
+- Code scanning (`codeql.yml`)
+- Dependabot updates (`.github/dependabot.yml`)
 
-## Data flow
-1. User provides passphrase + planner config.
-2. `scrypt` derives master key.
-3. Planner transcript digest is derived and mixed into per-round keystream.
-4. 3D keyed knight permutation + substitution rounds produce ciphertext body.
-5. Header includes planner hash and metadata.
-6. HMAC-SHA3-256 authenticates header+body.
+## 5. Deployment
+- Verifier contract: hiện là scaffold (`hksc-verifier-contract/contracts/HKSC_Verifier.sol`)
+- Production path:
+  1. Export verifier từ `snarkjs`
+  2. Replace scaffold
+  3. Run security pipeline + manual review
+  4. Deploy testnet trước, mainnet sau khi audit
 
-## Security boundaries
-- Core cipher can run without Flask/web3 dependencies.
-- Web3 is lazy-imported to avoid implicit chain/network coupling.
-- Placeholder smart contract is intentionally non-production and clearly marked.
-
-## CI/Security pipeline
-- Python unit tests workflow for functional regressions.
-- Contract security workflow combining Slither + Echidna + Mythril.
-- CodeQL code scanning workflow for Python + JavaScript.
-- Dependabot for GitHub Actions and npm ecosystem updates.
-
-
-## Autonomous Development Plan (Guarded)
-- `automation/policy.yaml` defines decision boundaries, escalation rules, and worst-case simulation lanes.
-- `automation/autonomy_engine.py` runs health checks, simulation checks, and emits machine-readable status reports.
-- `.github/workflows/autonomous-control-loop.yml` executes every 6 hours to continuously monitor and recommend next actions.
-- The system is intentionally **safe-autonomy**: it can suggest/prepare low-risk actions, but high-risk domains still require human escalation.
+**Full math/security discussion**: xem `docs/WHITEPAPER.md`.

--- a/docs/SECURITY_SETUP.md
+++ b/docs/SECURITY_SETUP.md
@@ -1,0 +1,25 @@
+# GitHub Security Setup (Native)
+
+## 1) Code Scanning
+- Repository → **Settings** → **Code security and analysis**
+- Enable **Code scanning** (default CodeQL setup is acceptable)
+
+## 2) Security Alerts
+In the same page, enable:
+- Dependabot alerts
+- Dependabot security updates
+- Secret scanning
+- Secret scanning push protection (if available on plan)
+
+## 3) Branch Protection
+- Settings → Branches → Add rule for `main`
+- Require status checks to pass before merge
+- Select all security workflows:
+  - `Full Security Pipeline (Slither + Echidna + Mythril)`
+  - `Contract Security (Slither + Echidna + Mythril)`
+  - `CodeQL`
+  - `Python tests`
+
+## 4) Operational Advice
+- Keep scaffold verifier out of production until replaced by generated verifier and audited.
+- Run testnet deploy first, then mainnet with explicit human approval.

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -57,3 +57,13 @@ Roadmap:
 2. Cross-language test vectors.
 3. Formal serialization spec.
 4. Third-party audit.
+
+
+## Operational Autonomy Model
+HKSC-4096 now includes a guarded autonomy loop for:
+- continuous monitoring,
+- automatic repair proposals,
+- adaptive worst-case simulations,
+- progressive optimization recommendations.
+
+Full decision delegation is constrained by policy: production secrets, irreversible migrations, and mainnet deploy actions remain human-gated.

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -1,0 +1,59 @@
+# HKSC-4096 Whitepaper (Engineering Draft)
+
+## Abstract
+HKSC-4096 is an experimental cryptographic construction that combines a 4096-cell supercube permutation model with a deterministic planner transcript to provide configurable domain separation. The system aims to be practical for experimentation while preserving deterministic replay for verification, simulation, and integration workflows.
+
+## Design goals
+- Deterministic reproducibility for encryption/decryption under explicit planner configuration.
+- Strict authentication failure on passphrase mismatch or planner mismatch.
+- Practical integration paths (CLI, Flask API, contract verification scaffolding).
+- Security-first pipeline support (static analysis, fuzzing, symbolic analysis, code scanning).
+
+## Threat model (current)
+The system defends against:
+- Passive eavesdroppers reading ciphertext.
+- Active tampering of ciphertext/header.
+- Configuration drift between encrypt/decrypt environments.
+
+The system does **not** claim formal proof security or replacement for audited standardized AEAD.
+
+## Cryptographic composition
+1. **KDF**: `scrypt(passphrase, salt)` derives key material.
+2. **Permutation**: keyed 3D knight-walk over 16×16×16 coordinate space with fallback coverage.
+3. **Round transform**: substitution + XOR keystream.
+4. **Authentication**: HMAC-SHA3-256 over header+body.
+5. **Planner binding**: planner configuration hash embedded in ciphertext header.
+
+## Planner model
+Planner digest is deterministic over:
+- piece mobility class,
+- agent count,
+- ratio mode (`equal`, `knight_less`, `knight_more`, `dynamic`),
+- dynamic schedule segments,
+- adversarial timing settings.
+
+Planner digest is mixed into keystream derivation and delta evolution, making ciphertext dependent on planner semantics.
+
+## Interoperability
+- CLI supports encrypt/decrypt/simulate/serve.
+- Flask bridge supports JSON APIs for UI tooling.
+- Web3 helper supports ABI-driven verifier invocation.
+- Contract scaffold supports future replacement with generated Groth16 verifier.
+
+## Security operations
+Recommended baseline:
+- Enforce branch protections.
+- Require passing unit tests + security workflows.
+- Enable Dependabot alerts + secret scanning + code scanning.
+- Replace placeholder verifier before any public deployment.
+
+## Limitations and roadmap
+- No formal reduction proof.
+- Planner currently hash-chain abstraction (not full Rubik group solver).
+- Smart contract currently placeholder.
+
+Roadmap:
+1. Generated verifier contract + ABI pinning.
+2. Cross-language test vectors.
+3. Formal serialization spec.
+4. Third-party audit.

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -1,69 +1,57 @@
-# HKSC-4096 Whitepaper (Engineering Draft)
+# HKSC-4096: HyperKnight Supercube Cryptosystem
+**A Post-Quantum-Oriented Experimental Primitive based on 3D Knight Permutation on 16³ Supercube**
+
+**Version 1.0 – February 2026**  
+**Author**: HKSC contributors  
+**Project**: HKSC-4096
 
 ## Abstract
-HKSC-4096 is an experimental cryptographic construction that combines a 4096-cell supercube permutation model with a deterministic planner transcript to provide configurable domain separation. The system aims to be practical for experimentation while preserving deterministic replay for verification, simulation, and integration workflows.
+We present HKSC-4096, an experimental cryptographic construction combining:
+- a 16×16×16 supercube permutation space,
+- deterministic planner transcript binding,
+- authenticated encryption pipeline,
+- optional on-chain verification integration,
+- CI-first security operations.
 
-## Design goals
-- Deterministic reproducibility for encryption/decryption under explicit planner configuration.
-- Strict authentication failure on passphrase mismatch or planner mismatch.
-- Practical integration paths (CLI, Flask API, contract verification scaffolding).
-- Security-first pipeline support (static analysis, fuzzing, symbolic analysis, code scanning).
+The design target is reproducible experimentation and operational hardening, while avoiding unsafe fully-autonomous high-risk actions.
 
-## Threat model (current)
-The system defends against:
-- Passive eavesdroppers reading ciphertext.
-- Active tampering of ciphertext/header.
-- Configuration drift between encrypt/decrypt environments.
+## 1. Introduction
+HKSC-4096 is designed as a practical R&D platform where cryptographic core, simulation/planner semantics, and integration layers can evolve independently. The main objective is deterministic reproducibility under explicit planner configuration.
 
-The system does **not** claim formal proof security or replacement for audited standardized AEAD.
+## 2. Mathematical Foundation (Engineering Level)
+- Supercube index space: `16^3 = 4096` cells.
+- Knight offset family in 3D for permutation walk candidates.
+- Planner-driven deterministic transcript digest (SHA3 chain).
+- Cipher rounds combining substitution and keyed permutation.
+- Integrity via HMAC over header+body.
 
-## Cryptographic composition
-1. **KDF**: `scrypt(passphrase, salt)` derives key material.
-2. **Permutation**: keyed 3D knight-walk over 16×16×16 coordinate space with fallback coverage.
-3. **Round transform**: substitution + XOR keystream.
-4. **Authentication**: HMAC-SHA3-256 over header+body.
-5. **Planner binding**: planner configuration hash embedded in ciphertext header.
+## 3. Security Analysis (Current Scope)
+- Brute-force resistance is dominated by passphrase/KDF strength and authenticated transform chain.
+- Tampering is detected by HMAC.
+- Config drift is detected by planner hash binding.
+- ML/quantum resistance claims are exploratory and **not** treated as proven guarantees.
 
-## Planner model
-Planner digest is deterministic over:
-- piece mobility class,
-- agent count,
-- ratio mode (`equal`, `knight_less`, `knight_more`, `dynamic`),
-- dynamic schedule segments,
-- adversarial timing settings.
+## 4. Implementation
+- Python core: `hksc4096.py`
+- API bridge: `hksc_bridge.py`
+- Web3 helper: `hksc_web3.py`
+- Contract scaffold + deploy skeleton: `hksc-verifier-contract/`
+- Security workflows: Slither, Echidna, Mythril, Manticore, CodeQL
 
-Planner digest is mixed into keystream derivation and delta evolution, making ciphertext dependent on planner semantics.
+## 5. Use Cases
+- Experimental data vault encryption with deterministic simulation semantics.
+- Planner-bound reproducible encryption/decryption testing.
+- Security research pipeline for verifier contracts before production deployment.
 
-## Interoperability
-- CLI supports encrypt/decrypt/simulate/serve.
-- Flask bridge supports JSON APIs for UI tooling.
-- Web3 helper supports ABI-driven verifier invocation.
-- Contract scaffold supports future replacement with generated Groth16 verifier.
+## 6. Governance & Safety
+HKSC-4096 applies guarded automation:
+- low-risk automation allowed (tests/docs/non-prod CI updates),
+- high-risk actions (mainnet deploy, secrets mutation, destructive ops) require human escalation.
 
-## Security operations
-Recommended baseline:
-- Enforce branch protections.
-- Require passing unit tests + security workflows.
-- Enable Dependabot alerts + secret scanning + code scanning.
-- Replace placeholder verifier before any public deployment.
+## References
+- Rubik/supercube combinatorics literature
+- Knight tour graph literature
+- VDF and zk-proof engineering references
+- Solidity static/symbolic/fuzz tooling docs
 
-## Limitations and roadmap
-- No formal reduction proof.
-- Planner currently hash-chain abstraction (not full Rubik group solver).
-- Smart contract currently placeholder.
-
-Roadmap:
-1. Generated verifier contract + ABI pinning.
-2. Cross-language test vectors.
-3. Formal serialization spec.
-4. Third-party audit.
-
-
-## Operational Autonomy Model
-HKSC-4096 now includes a guarded autonomy loop for:
-- continuous monitoring,
-- automatic repair proposals,
-- adaptive worst-case simulations,
-- progressive optimization recommendations.
-
-Full decision delegation is constrained by policy: production secrets, irreversible migrations, and mainnet deploy actions remain human-gated.
+**License**: MIT (repository default).

--- a/hksc-verifier-contract/README.md
+++ b/hksc-verifier-contract/README.md
@@ -1,0 +1,9 @@
+# HKSC Verifier Contract
+
+This folder is a deploy scaffold for zk-proof verification.
+
+## Replace before production
+1. Generate verifier from snarkjs:
+   - `snarkjs zkey export solidityverifier hksc_tour_final.zkey contracts/HKSC_Verifier.sol`
+2. Compile/deploy with Hardhat.
+3. Export ABI and configure `hksc_web3.py`.

--- a/hksc-verifier-contract/contracts/HKSC_Verifier.sol
+++ b/hksc-verifier-contract/contracts/HKSC_Verifier.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Placeholder verifier interface-compatible contract.
+/// Replace with snarkjs-generated verifier for production.
+contract HKSC_Verifier {
+    function verifyProof(
+        uint256[2] memory,
+        uint256[2][2] memory,
+        uint256[2] memory,
+        uint256[4] memory
+    ) public pure returns (bool) {
+        return true;
+    }
+}

--- a/hksc-verifier-contract/echidna.yaml
+++ b/hksc-verifier-contract/echidna.yaml
@@ -1,0 +1,6 @@
+testMode: assertion
+seqLen: 50
+testLimit: 20000
+workers: 2
+sender: ['0x10000', '0x20000', '0x30000']
+corpusDir: echidna-corpus

--- a/hksc-verifier-contract/scripts/deploy.js
+++ b/hksc-verifier-contract/scripts/deploy.js
@@ -1,0 +1,11 @@
+async function main() {
+  const Verifier = await ethers.getContractFactory('HKSC_Verifier');
+  const verifier = await Verifier.deploy();
+  await verifier.waitForDeployment();
+  console.log('HKSC_Verifier deployed to:', verifier.target);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/hksc4096.py
+++ b/hksc4096.py
@@ -1,0 +1,426 @@
+"""HKSC-4096: HyperKnight Supercube Cryptosystem (16x16x16).
+
+This implementation has two practical layers:
+1) HKSC4096Cipher: authenticated file encryption using 4096-byte supercube blocks.
+2) HKSCPlanner: deterministic simulation engine for the Rubik/Knight scheduling ideas
+   (3 base cases + dynamic ratio + multi-agent + piece variants as abstractions).
+
+The planner is used to derive additional domain-separated key material, so the
+"path + schedule" logic can influence encryption in a reproducible way.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import argparse
+import getpass
+import hashlib
+import hmac
+import json
+import os
+import struct
+from typing import Iterable, Sequence
+
+CUBE_SIDE = 16
+BLOCK_SIZE = CUBE_SIDE**3  # 4096
+SURFACE_CELLS = 6 * CUBE_SIDE * CUBE_SIDE  # 1536 stickers on 6 faces for 16x16
+MAGIC = b"HKSC2"
+
+
+def _index_to_xyz(index: int) -> tuple[int, int, int]:
+    z, rem = divmod(index, CUBE_SIDE * CUBE_SIDE)
+    y, x = divmod(rem, CUBE_SIDE)
+    return x, y, z
+
+
+def _xyz_to_index(x: int, y: int, z: int) -> int:
+    return z * CUBE_SIDE * CUBE_SIDE + y * CUBE_SIDE + x
+
+
+def _knight_offsets_3d() -> list[tuple[int, int, int]]:
+    offsets = set()
+    for zero_axis in range(3):
+        axes = [0, 1, 2]
+        axes.remove(zero_axis)
+        for a, b in ((2, 1), (1, 2)):
+            for sa in (-1, 1):
+                for sb in (-1, 1):
+                    v = [0, 0, 0]
+                    v[axes[0]] = sa * a
+                    v[axes[1]] = sb * b
+                    offsets.add(tuple(v))
+    return sorted(offsets)
+
+
+KNIGHT_OFFSETS = _knight_offsets_3d()
+
+
+class HKSCError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class HKSCConfig:
+    rounds: int = 10
+    scrypt_n: int = 2**14
+    scrypt_r: int = 8
+    scrypt_p: int = 1
+
+
+@dataclass(frozen=True)
+class PlannerConfig:
+    piece: str = "knight"  # knight|bishop|rook|queen|king (abstracted mobility classes)
+    agents: int = 1
+    ratio_mode: str = "equal"  # equal|knight_less|knight_more|dynamic
+    ratio_num: int = 1
+    ratio_den: int = 1
+    dynamic_schedule: tuple[tuple[int, int, int], ...] = ((512, 1, 1), (512, 1, 3), (512, 3, 1))
+    adversarial_interval: int = 50
+    adversarial_chance_pct: int = 7
+
+
+class HKSCPlanner:
+    """Deterministic abstraction of Rubik x Knight scheduling constraints.
+
+    We model the combined process as a transcript hash. This keeps runtime practical,
+    while still honoring requested control knobs (ratio, dynamic ratio, piece type,
+    multi-agent, adversarial events).
+    """
+
+    def __init__(self, seed: bytes, cfg: PlannerConfig):
+        self.seed = seed
+        self.cfg = cfg
+
+    def _hash(self, *chunks: bytes) -> bytes:
+        h = hashlib.sha3_512()
+        for c in chunks:
+            h.update(c)
+        return h.digest()
+
+    def _piece_weight(self) -> int:
+        return {
+            "knight": 37,
+            "bishop": 23,
+            "rook": 19,
+            "queen": 53,
+            "king": 11,
+        }.get(self.cfg.piece, 37)
+
+    def _twists_for_step(self, step: int, progress: int) -> int:
+        if self.cfg.ratio_mode == "equal":
+            return 1
+        if self.cfg.ratio_mode == "knight_less":
+            # Knight step triggers many twists (case 2, e.g. 1:8).
+            return max(1, self.cfg.ratio_den // max(1, self.cfg.ratio_num))
+        if self.cfg.ratio_mode == "knight_more":
+            # Many knight steps per twist (case 3), so sparse twists.
+            k = max(1, self.cfg.ratio_den)
+            return 1 if (step + 1) % k == 0 else 0
+
+        # dynamic: segments of (limit, num, den)
+        done = progress
+        for limit, num, den in self.cfg.dynamic_schedule:
+            if done < limit:
+                if num <= den:
+                    return max(1, den // max(1, num))
+                return 1 if (step + 1) % max(1, num // den) == 0 else 0
+            done -= limit
+        return 1
+
+    def run_transcript(self, total_cells: int = BLOCK_SIZE) -> bytes:
+        if self.cfg.agents < 1:
+            raise HKSCError("agents must be >= 1")
+
+        state = self._hash(b"HKSC-PLANNER", self.seed)
+        visited = 0
+
+        for step in range(total_cells):
+            base = self._hash(state, struct.pack(">I", step))
+            twists = self._twists_for_step(step, visited)
+            adversarial = (
+                self.cfg.adversarial_interval > 0
+                and step > 0
+                and step % self.cfg.adversarial_interval == 0
+                and base[0] < self.cfg.adversarial_chance_pct * 255 // 100
+            )
+
+            # Multi-agent contributes broader coverage per system step.
+            gain = min(self.cfg.agents, total_cells - visited)
+            visited += gain
+
+            state = self._hash(
+                state,
+                b"S",
+                struct.pack(">H", self._piece_weight()),
+                struct.pack(">H", self.cfg.agents),
+                struct.pack(">H", twists),
+                b"A" if adversarial else b"N",
+                base,
+            )
+
+        return state
+
+
+class HKSC4096Cipher:
+    def __init__(
+        self,
+        passphrase: str,
+        config: HKSCConfig | None = None,
+        planner_config: PlannerConfig | None = None,
+    ):
+        if not passphrase:
+            raise ValueError("Passphrase must not be empty")
+        self.passphrase = passphrase.encode("utf-8")
+        self.config = config or HKSCConfig()
+        self.planner_config = planner_config or PlannerConfig()
+
+    def _derive_master_key(self, salt: bytes) -> bytes:
+        return hashlib.scrypt(
+            self.passphrase,
+            salt=salt,
+            n=self.config.scrypt_n,
+            r=self.config.scrypt_r,
+            p=self.config.scrypt_p,
+            dklen=96,
+        )
+
+    @staticmethod
+    def _pad(data: bytes) -> bytes:
+        pad_len = (-len(data)) % BLOCK_SIZE
+        return data + (b"\x00" * pad_len)
+
+    def _hash_stream(self, seed: bytes, domain: bytes, length: int) -> bytes:
+        out = bytearray()
+        counter = 0
+        while len(out) < length:
+            out.extend(hashlib.sha3_256(seed + domain + struct.pack(">Q", counter)).digest())
+            counter += 1
+        return bytes(out[:length])
+
+    def _build_permutation(self, seed: bytes) -> list[int]:
+        visited = [False] * BLOCK_SIZE
+        perm: list[int] = []
+        stream = self._hash_stream(seed, b"perm", BLOCK_SIZE * 8)
+        current = int.from_bytes(stream[:8], "big") % BLOCK_SIZE
+
+        for step in range(BLOCK_SIZE):
+            visited[current] = True
+            perm.append(current)
+            if step == BLOCK_SIZE - 1:
+                break
+
+            cx, cy, cz = _index_to_xyz(current)
+            candidates: list[tuple[int, int, int]] = []
+            for dx, dy, dz in KNIGHT_OFFSETS:
+                nx, ny, nz = cx + dx, cy + dy, cz + dz
+                if 0 <= nx < CUBE_SIDE and 0 <= ny < CUBE_SIDE and 0 <= nz < CUBE_SIDE:
+                    ni = _xyz_to_index(nx, ny, nz)
+                    if visited[ni]:
+                        continue
+                    onward = 0
+                    for ddx, ddy, ddz in KNIGHT_OFFSETS:
+                        tx, ty, tz = nx + ddx, ny + ddy, nz + ddz
+                        if 0 <= tx < CUBE_SIDE and 0 <= ty < CUBE_SIDE and 0 <= tz < CUBE_SIDE:
+                            ti = _xyz_to_index(tx, ty, tz)
+                            if not visited[ti]:
+                                onward += 1
+                    bias = stream[(step * 13) % len(stream)]
+                    candidates.append((onward, bias, ni))
+
+            if candidates:
+                candidates.sort(key=lambda t: (t[0], t[1]))
+                current = candidates[0][2]
+                continue
+
+            jump = int.from_bytes(stream[(step * 8) % len(stream): (step * 8) % len(stream) + 8], "big")
+            current = jump % BLOCK_SIZE
+            while visited[current]:
+                current = (current + 1) % BLOCK_SIZE
+
+        return perm
+
+    def _planner_digest(self, planner_seed: bytes) -> bytes:
+        planner = HKSCPlanner(planner_seed, self.planner_config)
+        return planner.run_transcript(BLOCK_SIZE)
+
+    def encrypt(self, plaintext: bytes, *, salt: bytes | None = None, nonce: bytes | None = None) -> bytes:
+        salt = os.urandom(16) if salt is None else salt
+        nonce = os.urandom(16) if nonce is None else nonce
+        if len(salt) != 16 or len(nonce) != 16:
+            raise ValueError("salt and nonce must be 16 bytes each")
+
+        master = self._derive_master_key(salt)
+        perm = self._build_permutation(master[:32])
+        planner_digest = self._planner_digest(master[64:96])
+
+        padded = self._pad(plaintext)
+        blocks = [bytearray(padded[i : i + BLOCK_SIZE]) for i in range(0, len(padded), BLOCK_SIZE)]
+
+        for block_id, block in enumerate(blocks):
+            for r in range(self.config.rounds):
+                domain = b"round" + bytes([r]) + nonce + struct.pack(">I", block_id)
+                ks = self._hash_stream(master[32:64] + planner_digest, domain, BLOCK_SIZE)
+                transformed = bytearray(BLOCK_SIZE)
+                for i in range(BLOCK_SIZE):
+                    delta = (i * 17 + r * 31 + block_id * 13 + planner_digest[i % len(planner_digest)]) & 0xFF
+                    transformed[i] = ((block[i] + delta) & 0xFF) ^ ks[i]
+                permuted = bytearray(BLOCK_SIZE)
+                for i, p in enumerate(perm):
+                    permuted[p] = transformed[i]
+                block = permuted
+            blocks[block_id] = block
+
+        planner_json = json.dumps(self.planner_config.__dict__, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        planner_hash = hashlib.sha3_256(planner_json).digest()
+        header = MAGIC + salt + nonce + bytes([self.config.rounds]) + planner_hash + struct.pack(">Q", len(plaintext))
+        body = b"".join(blocks)
+        tag = hmac.new(master[64:96], header + body, hashlib.sha3_256).digest()
+        return header + body + tag
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        min_header = len(MAGIC) + 16 + 16 + 1 + 32 + 8
+        if len(ciphertext) < min_header + 32:
+            raise HKSCError("Ciphertext too short")
+
+        pos = 0
+        if ciphertext[: len(MAGIC)] != MAGIC:
+            raise HKSCError("Invalid magic")
+        pos += len(MAGIC)
+
+        salt = ciphertext[pos : pos + 16]
+        pos += 16
+        nonce = ciphertext[pos : pos + 16]
+        pos += 16
+        rounds = ciphertext[pos]
+        pos += 1
+
+        planner_hash = ciphertext[pos : pos + 32]
+        pos += 32
+
+        original_len = struct.unpack(">Q", ciphertext[pos : pos + 8])[0]
+        pos += 8
+
+        body = ciphertext[pos:-32]
+        tag = ciphertext[-32:]
+        if not body or len(body) % BLOCK_SIZE != 0:
+            raise HKSCError("Invalid ciphertext body length")
+
+        planner_json = json.dumps(self.planner_config.__dict__, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        expected_planner_hash = hashlib.sha3_256(planner_json).digest()
+        if not hmac.compare_digest(planner_hash, expected_planner_hash):
+            raise HKSCError("Planner configuration mismatch")
+
+        master = self._derive_master_key(salt)
+        expected_tag = hmac.new(master[64:96], ciphertext[: pos] + body, hashlib.sha3_256).digest()
+        if not hmac.compare_digest(tag, expected_tag):
+            raise HKSCError("Authentication failed: wrong passphrase or tampered data")
+
+        perm = self._build_permutation(master[:32])
+        planner_digest = self._planner_digest(master[64:96])
+
+        blocks = [bytearray(body[i : i + BLOCK_SIZE]) for i in range(0, len(body), BLOCK_SIZE)]
+        for block_id, block in enumerate(blocks):
+            for r in range(rounds - 1, -1, -1):
+                domain = b"round" + bytes([r]) + nonce + struct.pack(">I", block_id)
+                ks = self._hash_stream(master[32:64] + planner_digest, domain, BLOCK_SIZE)
+                unpermuted = bytearray(BLOCK_SIZE)
+                for i in range(BLOCK_SIZE):
+                    unpermuted[i] = block[perm[i]]
+                restored = bytearray(BLOCK_SIZE)
+                for i in range(BLOCK_SIZE):
+                    delta = (i * 17 + r * 31 + block_id * 13 + planner_digest[i % len(planner_digest)]) & 0xFF
+                    restored[i] = ((unpermuted[i] ^ ks[i]) - delta) & 0xFF
+                block = restored
+            blocks[block_id] = block
+
+        plaintext = b"".join(blocks)
+        if original_len > len(plaintext):
+            raise HKSCError("Invalid original length in header")
+        return plaintext[:original_len]
+
+
+def _parse_dynamic_schedule(raw: str | None) -> tuple[tuple[int, int, int], ...]:
+    if not raw:
+        return PlannerConfig().dynamic_schedule
+    parts = []
+    for seg in raw.split(","):
+        a, b, c = seg.split(":")
+        parts.append((int(a), int(b), int(c)))
+    return tuple(parts)
+
+
+def _make_planner_config(args: argparse.Namespace) -> PlannerConfig:
+    return PlannerConfig(
+        piece=getattr(args, "piece", "knight"),
+        agents=getattr(args, "agents", 1),
+        ratio_mode=getattr(args, "ratio_mode", "equal"),
+        ratio_num=getattr(args, "ratio_num", 1),
+        ratio_den=getattr(args, "ratio_den", 1),
+        dynamic_schedule=_parse_dynamic_schedule(getattr(args, "dynamic_schedule", None)),
+        adversarial_interval=getattr(args, "adversarial_interval", 50),
+        adversarial_chance_pct=getattr(args, "adversarial_chance_pct", 7),
+    )
+
+
+def _add_shared_planner_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--piece", default="knight", choices=["knight", "bishop", "rook", "queen", "king"])
+    p.add_argument("--agents", type=int, default=1)
+    p.add_argument("--ratio-mode", default="equal", choices=["equal", "knight_less", "knight_more", "dynamic"])
+    p.add_argument("--ratio-num", type=int, default=1)
+    p.add_argument("--ratio-den", type=int, default=1)
+    p.add_argument("--dynamic-schedule", help="Format: limit:num:den,limit:num:den")
+    p.add_argument("--adversarial-interval", type=int, default=50)
+    p.add_argument("--adversarial-chance-pct", type=int, default=7)
+
+
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="HKSC-4096 utility")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    enc = sub.add_parser("encrypt", help="Encrypt a file")
+    enc.add_argument("-i", "--input", required=True)
+    enc.add_argument("-o", "--output", required=True)
+    enc.add_argument("-p", "--passphrase")
+    _add_shared_planner_args(enc)
+
+    dec = sub.add_parser("decrypt", help="Decrypt a file")
+    dec.add_argument("-i", "--input", required=True)
+    dec.add_argument("-o", "--output", required=True)
+    dec.add_argument("-p", "--passphrase")
+    _add_shared_planner_args(dec)
+
+    sim = sub.add_parser("simulate", help="Simulate planner transcript only")
+    sim.add_argument("--seed", default="demo-seed")
+    sim.add_argument("--cells", type=int, default=BLOCK_SIZE)
+    _add_shared_planner_args(sim)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if args.cmd == "simulate":
+        cfg = _make_planner_config(args)
+        planner = HKSCPlanner(args.seed.encode("utf-8"), cfg)
+        digest = planner.run_transcript(args.cells)
+        print(json.dumps({"digest": digest.hex(), "cells": args.cells, "planner": cfg.__dict__}, indent=2))
+        return 0
+
+    passphrase = args.passphrase or getpass.getpass("Passphrase: ")
+    planner_cfg = _make_planner_config(args)
+    cipher = HKSC4096Cipher(passphrase, planner_config=planner_cfg)
+
+    with open(args.input, "rb") as f:
+        data = f.read()
+
+    out = cipher.encrypt(data) if args.cmd == "encrypt" else cipher.decrypt(data)
+
+    with open(args.output, "wb") as f:
+        f.write(out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hksc4096.py
+++ b/hksc4096.py
@@ -394,6 +394,10 @@ def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     sim.add_argument("--cells", type=int, default=BLOCK_SIZE)
     _add_shared_planner_args(sim)
 
+    serve = sub.add_parser("serve", help="Run Flask API bridge for desktop/web UI")
+    serve.add_argument("--host", default="127.0.0.1")
+    serve.add_argument("--port", type=int, default=5000)
+
     return parser.parse_args(argv)
 
 
@@ -405,6 +409,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         planner = HKSCPlanner(args.seed.encode("utf-8"), cfg)
         digest = planner.run_transcript(args.cells)
         print(json.dumps({"digest": digest.hex(), "cells": args.cells, "planner": cfg.__dict__}, indent=2))
+        return 0
+
+    if args.cmd == "serve":
+        try:
+            from hksc_bridge import create_app
+        except Exception as exc:
+            raise SystemExit(f"Flask bridge unavailable: {exc}")
+        app = create_app()
+        app.run(host=args.host, port=args.port, debug=False)
         return 0
 
     passphrase = args.passphrase or getpass.getpass("Passphrase: ")

--- a/hksc4096.py
+++ b/hksc4096.py
@@ -25,6 +25,7 @@ CUBE_SIDE = 16
 BLOCK_SIZE = CUBE_SIDE**3  # 4096
 SURFACE_CELLS = 6 * CUBE_SIDE * CUBE_SIDE  # 1536 stickers on 6 faces for 16x16
 MAGIC = b"HKSC2"
+LEGACY_MAGIC = b"HKSC1"
 
 
 def _index_to_xyz(index: int) -> tuple[int, int, int]:
@@ -283,7 +284,8 @@ class HKSC4096Cipher:
             raise HKSCError("Ciphertext too short")
 
         pos = 0
-        if ciphertext[: len(MAGIC)] != MAGIC:
+        magic = ciphertext[: len(MAGIC)]
+        if magic not in (MAGIC, LEGACY_MAGIC):
             raise HKSCError("Invalid magic")
         pos += len(MAGIC)
 

--- a/hksc_bridge.py
+++ b/hksc_bridge.py
@@ -1,0 +1,67 @@
+"""Flask bridge for Electron/Desktop integration."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import asdict
+from flask import Flask, jsonify, request
+
+from hksc4096 import HKSC4096Cipher, HKSCPlanner, PlannerConfig, _parse_dynamic_schedule
+
+
+def _planner_from_json(payload: dict) -> PlannerConfig:
+    dynamic = payload.get("dynamic_schedule")
+    if isinstance(dynamic, str):
+        dynamic_schedule = _parse_dynamic_schedule(dynamic)
+    elif isinstance(dynamic, list):
+        dynamic_schedule = tuple(tuple(int(v) for v in seg) for seg in dynamic)
+    else:
+        dynamic_schedule = PlannerConfig().dynamic_schedule
+
+    return PlannerConfig(
+        piece=payload.get("piece", "knight"),
+        agents=int(payload.get("agents", 1)),
+        ratio_mode=payload.get("ratio_mode", "equal"),
+        ratio_num=int(payload.get("ratio_num", 1)),
+        ratio_den=int(payload.get("ratio_den", 1)),
+        dynamic_schedule=dynamic_schedule,
+        adversarial_interval=int(payload.get("adversarial_interval", 50)),
+        adversarial_chance_pct=int(payload.get("adversarial_chance_pct", 7)),
+    )
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.get("/health")
+    def health():
+        return jsonify({"status": "ok"})
+
+    @app.post("/api/simulate")
+    def api_simulate():
+        body = request.get_json(force=True)
+        cfg = _planner_from_json(body)
+        seed = body.get("seed", "demo-seed").encode("utf-8")
+        cells = int(body.get("cells", 4096))
+        digest = HKSCPlanner(seed, cfg).run_transcript(cells)
+        return jsonify({"digest": digest.hex(), "planner": asdict(cfg), "cells": cells})
+
+    @app.post("/api/encrypt")
+    def api_encrypt():
+        body = request.get_json(force=True)
+        planner = _planner_from_json(body)
+        cipher = HKSC4096Cipher(body["passphrase"], planner_config=planner)
+        plaintext = base64.b64decode(body["plaintext_b64"])
+        ciphertext = cipher.encrypt(plaintext)
+        return jsonify({"ciphertext_b64": base64.b64encode(ciphertext).decode("ascii")})
+
+    @app.post("/api/decrypt")
+    def api_decrypt():
+        body = request.get_json(force=True)
+        planner = _planner_from_json(body)
+        cipher = HKSC4096Cipher(body["passphrase"], planner_config=planner)
+        ciphertext = base64.b64decode(body["ciphertext_b64"])
+        plaintext = cipher.decrypt(ciphertext)
+        return jsonify({"plaintext_b64": base64.b64encode(plaintext).decode("ascii")})
+
+    return app

--- a/hksc_web3.py
+++ b/hksc_web3.py
@@ -1,0 +1,55 @@
+"""Web3 helpers for HKSC verifier integration.
+
+This module keeps blockchain logic separate from the core cipher so users can
+opt-in only when they need on-chain zk-proof verification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True)
+class VerifierConfig:
+    rpc_url: str
+    verifier_address: str
+    abi_path: str
+
+
+def load_verifier_abi(path: str | Path) -> list[dict[str, Any]]:
+    raw = Path(path).read_text(encoding="utf-8")
+    data = json.loads(raw)
+    if not isinstance(data, list):
+        raise ValueError("Verifier ABI JSON must be a list")
+    return data
+
+
+def normalize_proof(proof: dict[str, Any]) -> tuple[list[int], list[list[int]], list[int]]:
+    required = ("A", "B", "C")
+    if any(k not in proof for k in required):
+        raise ValueError("Proof must contain A, B, C")
+    a, b, c = proof["A"], proof["B"], proof["C"]
+    if len(a) != 2 or len(b) != 2 or len(c) != 2 or any(len(row) != 2 for row in b):
+        raise ValueError("Invalid Groth16 proof shape")
+    return [int(x) for x in a], [[int(x) for x in row] for row in b], [int(x) for x in c]
+
+
+def onchain_verify_zk_proof(
+    cfg: VerifierConfig,
+    proof: dict[str, Any],
+    public_inputs: Sequence[int],
+) -> bool:
+    """Call verifier.verifyProof(...) as eth_call (no state change)."""
+    from web3 import Web3  # imported lazily to avoid hard dependency for non-web3 users
+
+    w3 = Web3(Web3.HTTPProvider(cfg.rpc_url))
+    if not w3.is_connected():
+        raise RuntimeError("Cannot connect to EVM RPC")
+
+    abi = load_verifier_abi(cfg.abi_path)
+    contract = w3.eth.contract(address=cfg.verifier_address, abi=abi)
+    a, b, c = normalize_proof(proof)
+    return bool(contract.functions.verifyProof(a, b, c, list(map(int, public_inputs))).call())

--- a/tests/test_autonomy_engine.py
+++ b/tests/test_autonomy_engine.py
@@ -1,0 +1,33 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from automation import autonomy_engine
+
+
+class TestAutonomyEngine(unittest.TestCase):
+    def test_worst_case_matrix(self):
+        matrix = autonomy_engine.evaluate_worst_case()
+        self.assertIn("ci_failure", matrix)
+        self.assertIn("tampered_ciphertext", matrix)
+
+    def test_report_generation(self):
+        with tempfile.TemporaryDirectory() as d:
+            report = Path(d) / "report.json"
+            # emulate CLI invocation by temporarily overriding argv
+            import sys
+            old = sys.argv
+            sys.argv = ["autonomy_engine.py", "--report", str(report), "--quick"]
+            try:
+                rc = autonomy_engine.main()
+            finally:
+                sys.argv = old
+            self.assertIn(rc, (0, 1))
+            data = json.loads(report.read_text())
+            self.assertIn("status", data)
+            self.assertIn("checks", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_conflict_markers.py
+++ b/tests/test_conflict_markers.py
@@ -1,0 +1,17 @@
+import subprocess
+import unittest
+
+
+class TestConflictMarkers(unittest.TestCase):
+    def test_no_conflict_markers(self):
+        proc = subprocess.run(
+            ["python", "tools/check_conflict_markers.py"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hksc4096.py
+++ b/tests/test_hksc4096.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+
+from hksc4096 import HKSC4096Cipher, HKSCError, HKSCPlanner, PlannerConfig
+
+
+class TestHKSC4096(unittest.TestCase):
+    def setUp(self):
+        self.base = dict(salt=bytes(range(16)), nonce=bytes(range(16, 32)))
+
+    def test_round_trip_small(self):
+        cipher = HKSC4096Cipher("correct horse battery staple")
+        data = b"hello HKSC-4096"
+        encrypted = cipher.encrypt(data, **self.base)
+        decrypted = cipher.decrypt(encrypted)
+        self.assertEqual(decrypted, data)
+
+    def test_round_trip_with_dynamic_ratio(self):
+        cfg = PlannerConfig(ratio_mode="dynamic", dynamic_schedule=((200, 1, 1), (200, 1, 8), (200, 7, 1)))
+        cipher = HKSC4096Cipher("pass", planner_config=cfg)
+        data = os.urandom(5000)
+        encrypted = cipher.encrypt(data, **self.base)
+        decrypted = cipher.decrypt(encrypted)
+        self.assertEqual(decrypted, data)
+
+    def test_planner_mismatch_fails(self):
+        c1 = HKSC4096Cipher("pw", planner_config=PlannerConfig(piece="knight", agents=1))
+        c2 = HKSC4096Cipher("pw", planner_config=PlannerConfig(piece="queen", agents=2))
+        ct = c1.encrypt(b"secret", **self.base)
+        with self.assertRaises(HKSCError):
+            c2.decrypt(ct)
+
+    def test_wrong_passphrase_fails(self):
+        cipher = HKSC4096Cipher("good")
+        ct = cipher.encrypt(b"abc", **self.base)
+        with self.assertRaises(HKSCError):
+            HKSC4096Cipher("bad").decrypt(ct)
+
+    def test_planner_deterministic(self):
+        cfg = PlannerConfig(ratio_mode="knight_more", ratio_den=7, agents=3)
+        p1 = HKSCPlanner(b"seed", cfg).run_transcript(256)
+        p2 = HKSCPlanner(b"seed", cfg).run_transcript(256)
+        self.assertEqual(p1, p2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hksc4096.py
+++ b/tests/test_hksc4096.py
@@ -42,6 +42,18 @@ class TestHKSC4096(unittest.TestCase):
         p2 = HKSCPlanner(b"seed", cfg).run_transcript(256)
         self.assertEqual(p1, p2)
 
+    def test_legacy_magic_accepted(self):
+        import hmac, hashlib
+        cipher = HKSC4096Cipher("good")
+        ct = cipher.encrypt(b"compat", **self.base)
+        salt = ct[5:21]
+        body = ct[62:-32]
+        legacy_header = b"HKSC1" + ct[5:62]
+        master = cipher._derive_master_key(salt)
+        legacy_tag = hmac.new(master[64:96], legacy_header + body, hashlib.sha3_256).digest()
+        legacy = legacy_header + body + legacy_tag
+        self.assertEqual(cipher.decrypt(legacy), b"compat")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration_helpers.py
+++ b/tests/test_integration_helpers.py
@@ -1,0 +1,29 @@
+import json
+import tempfile
+import unittest
+
+from hksc_web3 import load_verifier_abi, normalize_proof
+
+
+class TestIntegrationHelpers(unittest.TestCase):
+    def test_load_abi(self):
+        with tempfile.NamedTemporaryFile("w+", suffix=".json") as f:
+            json.dump([{"name": "verifyProof", "type": "function"}], f)
+            f.flush()
+            abi = load_verifier_abi(f.name)
+        self.assertEqual(abi[0]["name"], "verifyProof")
+
+    def test_normalize_proof(self):
+        proof = {
+            "A": ["1", "2"],
+            "B": [["3", "4"], ["5", "6"]],
+            "C": ["7", "8"],
+        }
+        a, b, c = normalize_proof(proof)
+        self.assertEqual(a, [1, 2])
+        self.assertEqual(b, [[3, 4], [5, 6]])
+        self.assertEqual(c, [7, 8])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_conflict_markers.py
+++ b/tools/check_conflict_markers.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+TARGETS = [
+    Path("README.md"),
+    Path("hksc4096.py"),
+    Path("tests/test_hksc4096.py"),
+]
+MARKERS = ("<<<<<<<", "=======", ">>>>>>>")
+
+
+def main() -> int:
+    bad = []
+    for t in TARGETS:
+        txt = t.read_text(encoding="utf-8")
+        if any(m in txt for m in MARKERS):
+            bad.append(str(t))
+    if bad:
+        print("Conflict markers detected in:")
+        for b in bad:
+            print(f"- {b}")
+        return 1
+    print("No conflict markers found in conflict-prone files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide an experimental authenticated block cipher based on a 16×16×16 (=4096) supercube and a planner abstraction inspired by Rubik/knight scheduling to influence keystream material. 
- Allow reproducible planner-driven domain separation so encryption binds to planner configuration and rejects mismatched planner settings. 
- Ship a simple CLI for encrypt/decrypt/simulate and some unit tests to validate round trips, planner determinism and error cases.

### Description

- Add `hksc4096.py` which implements `HKSC4096Cipher` (authenticated file encryption over 4096-byte blocks) and `HKSCPlanner` (deterministic planner transcript with piece/agent/ratio/adversarial options). 
- Implement a keyed 3D knight-walk permutation builder, `scrypt`-based KDF, SHA3-based keystream generation, and authentication via `HMAC-SHA3-256`; planner transcript is mixed into keystream/domain separation and planner JSON hash is stored in the header. 
- Provide a CLI (`encrypt`, `decrypt`, `simulate`) with planner-related arguments, header format including magic/salt/nonce/rounds/planner-hash/original-length and an authentication tag, and robust validation/error messages on planner mismatch or authentication failure. 
- Update `README.md` with overview, usage examples, architecture notes and security caveats, and add unit tests in `tests/test_hksc4096.py` covering round-trips, dynamic ratio, planner mismatch, wrong passphrase, and planner determinism.

### Testing

- Ran the unit test module `tests/test_hksc4096.py` via `python -m unittest discover -s tests -v`. 
- All tests (`test_round_trip_small`, `test_round_trip_with_dynamic_ratio`, `test_planner_mismatch_fails`, `test_wrong_passphrase_fails`, `test_planner_deterministic`) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc4278990832093a534abafdf1e7b)