### PR TITLE
Allow empty ciphertext bodies in decrypt and add regression test

### DIFF
--- a/hksc4096.py
+++ b/hksc4096.py
@@ -196,7 +196,7 @@ class HKSC4096Cipher:
             raise HKSCError("Ciphertext too short for authentication tag")
         body = ciphertext[pos:-32]
         tag = ciphertext[-32:]
-        if not body or len(body) % BLOCK_SIZE != 0:
+        if len(body) % BLOCK_SIZE != 0:
             raise HKSCError("Invalid ciphertext body length")
 
         master = self._derive_master_key(salt)

--- a/tests/test_hksc4096.py
+++ b/tests/test_hksc4096.py
@@ -16,6 +16,12 @@ class TestHKSC4096(unittest.TestCase):
         decrypted = self.cipher.decrypt(encrypted)
         self.assertEqual(decrypted, data)
 
+    def test_round_trip_empty(self):
+        data = b""
+        encrypted = self.cipher.encrypt(data, salt=self.salt, nonce=self.nonce)
+        decrypted = self.cipher.decrypt(encrypted)
+        self.assertEqual(decrypted, data)
+
     def test_round_trip_block_plus(self):
         data = os.urandom(5000)
         encrypted = self.cipher.encrypt(data, salt=self.salt, nonce=self.nonce)


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where ciphertext produced by `encrypt(b"")` could not be decrypted because the decrypter rejected empty bodies even though padding produces a valid (zero-length) body.

### Description
- Update `hksc4096.py` to relax the body-length check in `decrypt` from `if not body or len(body) % BLOCK_SIZE != 0` to `if len(body) % BLOCK_SIZE != 0` so an empty body is accepted while still enforcing block alignment for non-empty bodies.
- Add a regression unit test `test_round_trip_empty` in `tests/test_hksc4096.py` that verifies `encrypt(b"")` round-trips through `decrypt` successfully.

### Testing
- Ran `python -m unittest discover -s tests -v` and all tests passed (`Ran 4 tests in ~5s

OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d8319c208320a2a4f9183f52d704)